### PR TITLE
Logging

### DIFF
--- a/nplab/__init__.py
+++ b/nplab/__init__.py
@@ -1,13 +1,14 @@
 """
 NPLab
 =====
-This module contains lots of classes and functions to support the 
+This module contains lots of classes and functions to support the
 NanoPhotonics group's lab work.
 """
 
 __author__ = 'alansanders,rwb27'
 __all__ = []
 
-from .datafile import current as current_datafile
-from .utils.array_with_attrs import ArrayWithAttrs
-from .utils.decorators import inherit_docstring
+from nplab.datafile import current as current_datafile
+from nplab.utils.array_with_attrs import ArrayWithAttrs
+from nplab.utils.decorators import inherit_docstring
+from nplab.utils.log import log

--- a/nplab/datafile.py
+++ b/nplab/datafile.py
@@ -159,8 +159,8 @@ class Group(h5py.Group):
         """Return a subgroup, creating it if it does not exist."""
         return Group(super(Group, self).require_group(name).id)  # wrap the returned group
 
-    def create_dataset(self, name, auto_increment=True, shape=None, dtype=None, data=None, attrs=None, timestamp=True,
-                       *args, **kwargs):
+    def create_dataset(self, name, auto_increment=True, shape=None, dtype=None,
+                       data=None, attrs=None, timestamp=True, *args, **kwargs):
         """Create a new dataset, optionally with an auto-incrementing name.
 
         :param name: the name of the new dataset
@@ -197,11 +197,13 @@ class Group(h5py.Group):
 
     def create_resizable_dataset(self, name, shape=(0,), maxshape=(None,), auto_increment=True, dtype=None, attrs=None, timestamp=True,
                                  *args, **kwargs):
+        """See create_dataset documentation"""
         return self.create_dataset(name, auto_increment, shape, dtype, attrs, timestamp,
                                    maxshape=maxshape, chunks=True, *args, **kwargs)
 
     def require_resizable_dataset(self, name, shape=(0,), maxshape=(None,), auto_increment=True, dtype=None, attrs=None, timestamp=True,
                                   *args, **kwargs):
+        """Create a resizeable dataset, or return the dataset if it exists."""
         if name not in self:
             dset = self.create_resizable_dataset(name, shape, maxshape, auto_increment, dtype, attrs, timestamp,
                                                  *args, **kwargs)
@@ -258,7 +260,7 @@ class Group(h5py.Group):
         """Return a file browser widget for this group."""
         from nplab.ui.hdf5_browser import HDF5Browser
         return HDF5Browser(self)
-        
+
 
 class DataFile(Group):
     """Represent an HDF5 file object.

--- a/nplab/instrument/__init__.py
+++ b/nplab/instrument/__init__.py
@@ -2,15 +2,16 @@
 Instrument Class
 ================
 
-This base class defines the standard behaviour for NPLab's instrument 
-classes.  
+This base class defines the standard behaviour for NPLab's instrument
+classes.
 """
 
 from nplab.utils.thread_utils import locked_action_decorator, background_action_decorator
 import nplab
-from traits.api import HasTraits, String
+#from traits.api import HasTraits, String
 
 from weakref import WeakSet
+import nplab.utils.log
 
 class Instrument(object):
     """Base class for all instrument-control classes.
@@ -18,7 +19,7 @@ class Instrument(object):
     This class takes care of management of instruments, saving data, etc.
     """
     __instances = None
-    description = String
+#    description = String
     metadata_property_names = () #"Tuple of names of properties that should be automatically saved as HDF5 metadata
 
     def __init__(self):
@@ -39,8 +40,8 @@ class Instrument(object):
 
     @classmethod
     def get_instance(cls, create=True, exceptions=True, *args, **kwargs):
-        """Return an instance of this class, if one exists.  
-        
+        """Return an instance of this class, if one exists.
+
         Usually returns the first available instance.
         """
         instances = cls.get_instances()
@@ -91,9 +92,18 @@ class Instrument(object):
             dset.file.flush() #make sure it's in the file if we wrote data
         return dset
 
+    def log(self, message):
+        """Save a log message to the current datafile.
+
+        This is the preferred way to output debug/informational messages.  They
+        will be saved in the current HDF5 file and optionally shown in the
+        nplab console.
+        """
+        nplab.utils.log.log(message, from_object=self)
+
     def get_metadata(self):
         """A dictionary of settings, properties, etc. to save along with data.
-        
+
         This returns the value of each property in self.metadata_property_names."""
         return {name: getattr(self,name) for name in self.metadata_property_names}
 
@@ -102,7 +112,7 @@ class Instrument(object):
 
     def show_gui(self, blocking=True):
         """Display a GUI window for the item of equipment.
-        
+
         You should override this method to display a window to control the
         instrument.  If edit_traits/configure_traits methods exist, we'll fall
         back to those as a default.

--- a/nplab/utils/log.py
+++ b/nplab/utils/log.py
@@ -10,6 +10,8 @@ Instrument (or possibly Experiment) should call self.log instead.
 import nplab
 import numpy as np
 
+print_logs_to_console = False
+
 def log(message, from_class=None, from_object=None,
         create_datafile=False, assert_datafile=False):
         """Add a message to the NPLab log, stored in the current datafile.
@@ -37,7 +39,9 @@ def log(message, from_class=None, from_object=None,
             df = nplab.current_datafile(create_if_none=create_datafile,
                                         create_if_closed=create_datafile)
             logs = df.require_group("nplab_log")
-            dset = logs.create_dataset("entry_%d", data=np.string(message))
+            dset = logs.create_dataset("entry_%d",
+                                       data=np.string_(message),
+                                       timestamp=True)
             #save the object and class if supplied.
             if from_object is not None:
                 dset.attrs.create("object",np.string_("%x" % id(from_object)))
@@ -49,6 +53,10 @@ def log(message, from_class=None, from_object=None,
                         pass
             if from_class is not None:
                 dset.attrs.create("class",np.string_(from_class))
+
+            #if nothing's gone wrong, and we've been asked to, print the message
+            if print_logs_to_console:
+                print "log: " + message
 
         except Exception as e:
             print "Couldn't log to file: " + message

--- a/nplab/utils/log.py
+++ b/nplab/utils/log.py
@@ -1,0 +1,57 @@
+"""
+Logging support functions
+
+It's useful for experiments (and items of equipment) to be able to log what's
+happening.  This module provides some support functions to help with that.
+Note that these usually won't be called directly - anything inheriting from
+Instrument (or possibly Experiment) should call self.log instead.
+"""
+
+import nplab
+import numpy as np
+
+def log(message, from_class=None, from_object=None,
+        create_datafile=False, assert_datafile=False):
+        """Add a message to the NPLab log, stored in the current datafile.
+
+        This function will put a message in the nplab_log group in the root of
+        the current datafile (i.e. the HDF5 file returned by
+        `nplab.current_datafile()`).  It is automatically timestamped and named.
+
+        @param: from_class: The class (or a string containing it) relating to
+        the message.  Automatically filled in if from_object is supplied.
+        @param: from_object: The object originating the log message.  We save a
+        string representing the object's ID (allows us to distinguish between
+        concurrent instances).
+        @param: create_datafile: By default, log messages are discarded before
+        the datafile exists - specifying True here will attempt to create a
+        new datafile (which may involve popping up a GUI).
+        @param: assert_datafile: Set to true to raise an exception if there is
+        no current datafile.
+
+        Note that if you are calling this from an `Instrument` subclass you
+        should consider using `self.log()` which automatically fills in the
+        object and class fields.
+        """
+        try:
+            df = nplab.current_datafile(create_if_none=create_datafile,
+                                        create_if_closed=create_datafile)
+            logs = df.require_group("nplab_log")
+            dset = logs.create_dataset("entry_%d", data=np.string(message))
+            #save the object and class if supplied.
+            if from_object is not None:
+                dset.attrs.create("object",np.string_("%x" % id(from_object)))
+                if from_class is None:
+                    #extract the class of the object if it's not specified
+                    try:
+                        from_class = from_object.__class__
+                    except:
+                        pass
+            if from_class is not None:
+                dset.attrs.create("class",np.string_(from_class))
+
+        except Exception as e:
+            print "Couldn't log to file: " + message
+            if assert_datafile:
+                print "Error saving log message - raising exception."
+                raise e

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -60,7 +60,11 @@ def test_long_log(tmpdir):
     N = 10000
     for i in range(N):
         instr.do_something()
-    assert len(df['nplab_log'].numbered_items("entry")) == N
+        print i
+    #assert len(df['nplab_log'].keys()) == N #SLOW!
+    assert df['nplab_log/entry_%d' % (N-1)], "Last log entry was missing!"
+    with pytest.raises(KeyError):
+        df['nplab_log/entry_%d' % N] #zero-indexet - this shouldn't exist!
 
     df.close()
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,68 @@
+import nplab
+from nplab.instrument import Instrument
+import nplab.datafile
+import pytest
+
+class InstrumentA(Instrument):
+    def do_something(self):
+        self.log("doing something")
+
+def test_datafile_assertion():
+    with pytest.raises(IOError):
+        #should fail because the datafile isn't open
+        nplab.log("Message", assert_datafile=True)
+
+def test_logging(tmpdir):
+    nplab.datafile.set_current(str(tmpdir.join("temp.h5")))
+    df = nplab.current_datafile()
+    assert df, "Error creating datafile!"
+    print df
+
+    nplab.log("test log message", assert_datafile=True) #make a log message
+    df.flush() #make sure the message makes it to the file...
+
+    print df['nplab_log'].keys()
+    entry = df['nplab_log'].numbered_items("entry")[-1]
+    assert entry.value == "test log message"
+    print entry.attrs.keys()
+    assert entry.attrs.get('creation_timestamp') is not None
+
+
+    nplab.log("test log message 2") #make a log message
+    assert len(df['nplab_log'].numbered_items("entry")) == 2
+
+    df.close()
+
+def test_logging_from_instrument(tmpdir):
+    nplab.datafile.set_current(str(tmpdir.join("temp.h5")))
+    df = nplab.current_datafile()
+    assert df, "Error creating datafile!"
+
+    instr = InstrumentA()
+
+    instr.do_something()
+
+    entry = df['nplab_log'].numbered_items("entry")[-1]
+    assert entry.value == "doing something"
+    assert entry.attrs.get('creation_timestamp') is not None
+    assert entry.attrs.get('object') is not None
+    assert entry.attrs.get('class') is not None
+
+    df.close()
+
+def test_long_log(tmpdir):
+    nplab.datafile.set_current(str(tmpdir.join("temp_long.h5")))
+    df = nplab.current_datafile()
+    assert df, "Error creating datafile!"
+
+    instr = InstrumentA()
+
+    N = 10000
+    for i in range(N):
+        instr.do_something()
+    assert len(df['nplab_log'].numbered_items("entry")) == N
+
+    df.close()
+
+if __name__ == "__main__":
+    pass


### PR DESCRIPTION
I’ve added Instrument.log and nplab.log (code in nplab.utils.log).  This writes to a folder in the current HDF5 file, and should be the canonical way to save debug/error messages from code.  In the future it might be nice to have some sort of on-line log viewing console.  That’s not currently implemented, but everything goes through nplab.utils.log.log() so it should be possible.