### PR TITLE
Prior single axis moves

### DIFF
--- a/nplab/instrument/message_bus_instrument.py
+++ b/nplab/instrument/message_bus_instrument.py
@@ -333,6 +333,26 @@ class EchoInstrument(MessageBusInstrument):
         return self._last_write
 
 
+def wrap_with_echo_to_console(obj):
+    """Modify an object on-the-fly so all its write and readline calls are echoed to the console"""
+    import functools
+
+    obj._debug_echo = True
+    obj._original_write = obj.write
+    obj._original_readline = obj.readline
+
+    def write(self, q, *args, **kwargs):
+        print "Sent: "+str(q)
+        return self._original_write(q, *args, **kwargs)
+    obj.write = functools.partial(write, obj)
+
+    def readline(self, *args, **kwargs):
+        ret = self._original_readline(*args, **kwargs)
+        print "Recv: "+str(ret)
+        return ret
+    obj.readline = functools.partial(readline, obj)
+
+
 if __name__ == '__main__':
     class DummyInstrument(EchoInstrument):
         x = queried_property('gx', 'sx {0}', dtype='str')

--- a/nplab/instrument/message_bus_instrument.py
+++ b/nplab/instrument/message_bus_instrument.py
@@ -12,6 +12,7 @@ This base class
 import re
 import nplab.instrument
 from functools import partial
+import threading
 
 
 class MessageBusInstrument(nplab.instrument.Instrument):
@@ -23,7 +24,10 @@ class MessageBusInstrument(nplab.instrument.Instrument):
 
     This base class provides commonly-used mechanisms that support the use of
     serial or VISA instruments.  The SerialInstrument and VISAInstrument classes
-    both inherit from this class.
+    both inherit from this class.  Most interactions with this class involve
+    a call to the `query` method.  This writes a message and returns the reply.
+    
+    
 
     Subclassing Notes
     -----------------
@@ -35,38 +39,67 @@ class MessageBusInstrument(nplab.instrument.Instrument):
 
     It's also a very good idea to provide some way to flush the input buffer
     with `flush_input_buffer()`.
+    
+    Threading Notes
+    ---------------
+    
+    The message bus protocol includes a property, `communications_lock`.  All
+    commands that use the communications bus should be protected by this lock.
+    It's also permissible to use it to protect sequences of calls to the bus 
+    that must be atomic (e.g. a multi-part exchange of messages).  However, try
+    not to hold it too long - or odd things might happen if other threads are 
+    blocked for a long time.  The lock is reentrant so there's no issue with
+    acquiring it twice.
     """
     termination_character = "\n" #: All messages to or from the instrument end with this character.
     termination_line = None #: If multi-line responses are recieved, they must end with this string
     ignore_echo = False
 
+    _communications_lock = None
+    @property
+    def communications_lock(self):
+        """A lock object used to protect access to the communications bus"""
+        # This requires initialisation but our init method won't be called - so
+        # the property initialises it on first use.
+        if self._communications_lock is None:
+            self._communications_lock = threading.RLock()
+        return self._communications_lock
+
     def write(self,query_string):
-        """Write a string to the serial port"""
-        raise NotImplementedError("Subclasses of MessageBusInstrument must override the write method!")
+        """Write a string to the unerlying communications port"""
+        with self.communications_lock:
+            raise NotImplementedError("Subclasses of MessageBusInstrument must override the write method!")
+            
     def flush_input_buffer(self):
         """Make sure there's nothing waiting to be read.
 
         This function should be overridden to make sure nothing's lurking in
         the input buffer that could confuse a query.
         """
-        pass
+        with self.communications_lock:
+            pass
+    
     def readline(self, timeout=None):
         """Read one line from the underlying bus.  Must be overriden."""
-        raise NotImplementedError("Subclasses of MessageBusInstrument must override the readline method!")
+        with self.communications_lock:
+            raise NotImplementedError("Subclasses of MessageBusInstrument must override the readline method!")
+            
     def read_multiline(self, termination_line=None, timeout=None):
         """Read one line from the underlying bus.  Must be overriden.
 
         This should not need to be reimplemented unless there's a more efficient
         way of reading multiple lines than multiple calls to readline()."""
-        if termination_line is None:
-            termination_line = self.termination_line
-        assert isinstance(termination_line, str), "If you perform a multiline query, you must specify a termination line either through the termination_line keyword argument or the termination_line property of the NPSerialInstrument."
-        response = ""
-        last_line = "dummy"
-        while termination_line not in last_line and len(last_line) > 0: #read until we get the termination line.
-            last_line = self.readline(timeout)
-            response += last_line
-        return response
+        with self.communications_lock:
+            if termination_line is None:
+                termination_line = self.termination_line
+            assert isinstance(termination_line, str), "If you perform a multiline query, you must specify a termination line either through the termination_line keyword argument or the termination_line property of the NPSerialInstrument."
+            response = ""
+            last_line = "dummy"
+            while termination_line not in last_line and len(last_line) > 0: #read until we get the termination line.
+                last_line = self.readline(timeout)
+                response += last_line
+            return response
+            
     def query(self,queryString,multiline=False,termination_line=None,timeout=None):
         """
         Write a string to the stage controller and return its response.
@@ -74,22 +107,23 @@ class MessageBusInstrument(nplab.instrument.Instrument):
         It will block until a response is received.  The multiline and termination_line commands
         will keep reading until a termination phrase is reached.
         """
-        self.flush_input_buffer()
-        self.write(queryString)
-        if self.ignore_echo == True: # Needs Implementing for a multiline read!
-            first_line = self.readline(timeout).strip()
-            if first_line == queryString:
-                return self.readline(timeout).strip()
+        with self.communications_lock:
+            self.flush_input_buffer()
+            self.write(queryString)
+            if self.ignore_echo == True: # Needs Implementing for a multiline read!
+                first_line = self.readline(timeout).strip()
+                if first_line == queryString:
+                    return self.readline(timeout).strip()
+                else:
+                    print 'This command did not echo!!!'
+                    return first_line
+    
+            if termination_line is not None:
+                multiline = True
+            if multiline:
+                return self.read_multiline(termination_line)
             else:
-                print 'This command did not echo!!!'
-                return first_line
-
-        if termination_line is not None:
-            multiline = True
-        if multiline:
-            return self.read_multiline(termination_line)
-        else:
-            return self.readline(timeout).strip() #question: should we strip the final newline?
+                return self.readline(timeout).strip() #question: should we strip the final newline?
     def parsed_query_old(self, query_string, response_string=r"(\d+)", re_flags=0, parse_function=int, **kwargs):
         """
         Perform a query, then parse the result.
@@ -100,6 +134,7 @@ class MessageBusInstrument(nplab.instrument.Instrument):
 
         TODO: make this accept friendlier sscanf style arguments, and produce parse functions automatically
         """
+        # NB no need for the lock here - `query` is already an atomic operation.
         reply = self.query(query_string, **kwargs)
         res = re.search(response_string, reply, flags=re_flags)
         if res is None:
@@ -180,6 +215,13 @@ class MessageBusInstrument(nplab.instrument.Instrument):
 
 
 class queried_property(object):
+    """A Property interface that reads and writes from the instrument on the bus.
+    
+    This returns a property-like (i.e. a descriptor) object.  You can use it
+    in a class definition just like a property.  The property it creates will
+    interact with the instrument over the communication bus to set and retrieve
+    its value.
+    """
     def __init__(self, get_cmd=None, set_cmd=None, validate=None, valrange=None,
                  fdel=None, doc=None, dtype='float'):
         self.dtype = dtype
@@ -232,6 +274,7 @@ class queried_property(object):
 
 
 class queried_channel_property(queried_property):
+    # I'm not sure what this does or who uses it.  I assume it's Alan's? --rwb27
     def __init__(self, get_cmd=None, set_cmd=None, validate=None, valrange=None,
                  fdel=None, doc=None, dtype='float'):
         super(queried_channel_property, self).__init__(get_cmd, set_cmd, validate, valrange,

--- a/nplab/instrument/serial_instrument.py
+++ b/nplab/instrument/serial_instrument.py
@@ -56,7 +56,7 @@ class SerialInstrument(MessageBusInstrument):
         Set up the serial port and so on.
         """
         MessageBusInstrument.__init__(self) # Using super() here can cause issues with multiple inheritance.
-        self.open(port, False)
+        self.open(port, False) # Eventually this shouldn't rely on init...
 
     def open(self, port=None, quiet=True):
         """Open communications with the serial port.
@@ -64,69 +64,80 @@ class SerialInstrument(MessageBusInstrument):
         If no port is specified, it will attempt to autodetect.  If quiet=True
         then we don't warn when ports are opened multiple times.
         """
-        if hasattr(self,'ser') and self.ser.isOpen():
-            if not quiet: print "Warning: attempted to open an already-open port!"
-            return
-        if port is None: port=self.find_port()
-        assert port is not None, "We don't have a serial port to open, meaning you didn't specify a valid port and autodetection failed.  Are you sure the instrument is connected?"
-        self.ser = serial.Serial(port,**self.port_settings)
-        self.ser_io = io.TextIOWrapper(io.BufferedRWPair(self.ser, self.ser, 1),  
-                                       newline = self.termination_character,
-                                       line_buffering = True)
-        #the block above wraps the serial IO layer with a text IO layer
-        #this allows us to read/write in neat lines.  NB the buffer size must
-        #be set to 1 byte for maximum responsiveness.
-        assert self.test_communications(), "The instrument doesn't seem to be responding.  Did you specify the right port?"
+        with self.communications_lock:
+            if hasattr(self,'ser') and self.ser.isOpen():
+                if not quiet: print "Warning: attempted to open an already-open port!"
+                return
+            if port is None: port=self.find_port()
+            assert port is not None, "We don't have a serial port to open, meaning you didn't specify a valid port and autodetection failed.  Are you sure the instrument is connected?"
+            self.ser = serial.Serial(port,**self.port_settings)
+            self.ser_io = io.TextIOWrapper(io.BufferedRWPair(self.ser, self.ser, 1),  
+                                           newline = self.termination_character,
+                                           line_buffering = True)
+            #the block above wraps the serial IO layer with a text IO layer
+            #this allows us to read/write in neat lines.  NB the buffer size must
+            #be set to 1 byte for maximum responsiveness.
+            assert self.test_communications(), "The instrument doesn't seem to be responding.  Did you specify the right port?"
+    
     def close(self):
-        try:
-            self.ser.close()
-        except Exception as e:
-            print "The serial port didn't close cleanly:", e
+        """Release the serial port"""
+        with self.communications_lock:
+            try:
+                self.ser.close()
+            except Exception as e:
+                print "The serial port didn't close cleanly:", e
+                
     def __del__(self):
         self.close()
+        
     def write(self,query_string):
         """Write a string to the serial port"""
-        assert self.ser.isOpen(), "Warning: attempted to write to the serial port before it was opened.  Perhaps you need to call the 'open' method first?"
-        try:        
-            if self.ser.outWaiting()>0: self.ser.flushOutput() #ensure there's nothing waiting
-        except AttributeError:
-            if self.ser.out_waiting>0: self.ser.flushOutput() #ensure there's nothing waiting
-        self.ser.write(query_string+self.termination_character)
+        with self.communications_lock:
+            assert self.ser.isOpen(), "Warning: attempted to write to the serial port before it was opened.  Perhaps you need to call the 'open' method first?"
+            try:        
+                if self.ser.outWaiting()>0: self.ser.flushOutput() #ensure there's nothing waiting
+            except AttributeError:
+                if self.ser.out_waiting>0: self.ser.flushOutput() #ensure there's nothing waiting
+            self.ser.write(query_string+self.termination_character)
 
     def flush_input_buffer(self):
         """Make sure there's nothing waiting to be read, and clear the buffer if there is."""
-        if self.ser.inWaiting()>0: self.ser.flushInput()
+        with self.communications_lock:
+            if self.ser.inWaiting()>0: self.ser.flushInput()
     def readline(self, timeout=None):
         """Read one line from the serial port."""
-        return self.ser_io.readline().replace(self.termination_character,"\n")
+        with self.communications_lock:
+            return self.ser_io.readline().replace(self.termination_character,"\n")
     def test_communications(self):
         """Check if the device is available on the current port.  
         
         This should be overridden by subclasses.  Assume the port has been
         successfully opened and the settings are as defined by self.port_settings.
         Usually this function sends a command and checks for a known reply."""
-        return True
+        with self.communications_lock:
+            return True
     def find_port(self):
         """Iterate through the available serial ports and query them to see
         if our instrument is there."""
-        success = False
-        for port_name, _, _ in serial.tools.list_ports.comports(): #loop through serial ports, apparently 256 is the limit?!
-            try:
-                print "Trying port",port_name
-                self.open(port_name)
-                success = True
-                print "Success!"
-            except:
-                pass
-            finally:
+        with self.communications_lock:
+            success = False
+            for port_name, _, _ in serial.tools.list_ports.comports(): #loop through serial ports, apparently 256 is the limit?!
                 try:
-                    self.close()
+                    print "Trying port",port_name
+                    self.open(port_name)
+                    success = True
+                    print "Success!"
                 except:
-                    pass #we don't care if there's an error closing the port...
+                    pass
+                finally:
+                    try:
+                        self.close()
+                    except:
+                        pass #we don't care if there's an error closing the port...
+                if success:
+                    break #again, make sure this happens *after* closing the port
             if success:
-                break #again, make sure this happens *after* closing the port
-        if success:
-            return port_name
-        else:
-            return None
+                return port_name
+            else:
+                return None
     

--- a/nplab/instrument/stage/__init__.py
+++ b/nplab/instrument/stage/__init__.py
@@ -21,8 +21,26 @@ import collections
 
 
 class Stage(Instrument):
+    """A class representing motion-control stages.
+    
+    This class primarily provides two things: the ability to find the position
+    of the stage (using `Stage.position` or `Stage.get_position(axis="a")`), 
+    and the ability to move the stage (see `Stage.move()`).
+    
+    Subclassing Notes
+    -----------------
+    The minimum you need to do in order to subclass this is to override the
+    `move` method and the `get_position` method.  NB you must handle the case
+    where `axis` is specified and where it is not.  For `move`, `move_axis` is
+    provided, which will help emulate single-axis moves on stages that can't 
+    make them natively.
+    
+    In the future, a class factory method might be available, that will 
+    simplify the emulation of various features.
+    """
+    axis_names = ('x', 'y', 'z')
     def __init__(self):
-        self.axis_names = ('x', 'y', 'z')
+        Instrument.__init__(self)
 
     def move(self, pos, axis=None, relative=False):
         raise NotImplementedError("You must override move() in a Stage subclass")

--- a/nplab/instrument/stage/prior.py
+++ b/nplab/instrument/stage/prior.py
@@ -81,6 +81,10 @@ class ProScan(serial.SerialInstrument, stage.Stage):
         except KeyboardInterrupt:
             self.emergency_stop()
 
+    def move_axis(self, pos, axis, relative=False, **kwargs):
+        """Move along one axis"""
+        return self.move(pos, axis=axis, relative=relative, **kwargs)
+
     def get_position(self, axis=None):
         """return the current position in microns"""
         if axis is not None:

--- a/nplab/instrument/stage/prior.py
+++ b/nplab/instrument/stage/prior.py
@@ -83,7 +83,11 @@ class ProScan(serial.SerialInstrument, stage.Stage):
 
     def move_axis(self, pos, axis, relative=False, **kwargs):
         """Move along one axis"""
-        return self.move(pos, axis=axis, relative=relative, **kwargs)
+        # We use the built-in emulation for relative moves
+        if relative:
+            return stage.Stage.move_axis(self, pos, axis, relative=True, **kwargs)
+        else:
+            return self.move(pos, axis=axis, relative=relative, **kwargs)
 
     def get_position(self, axis=None):
         """return the current position in microns"""

--- a/nplab/instrument/stage/prior.py
+++ b/nplab/instrument/stage/prior.py
@@ -59,9 +59,18 @@ class ProScan(serial.SerialInstrument, stage.Stage):
         we return immediately.  relative=True does relative motion, otherwise
         motion is absolute.
         """
-        if axis is not None:
+        querystring = "G"
+        if axis is not None and relative:
+            # single-axis emulation is fine for relative moves
             return self.move_axis(x, axis, relative=relative, block=block)
-        querystring = "GR" if relative else "G" #allow for absolute or relative moves
+        elif axis is not None and not relative:
+            # single-axis absolute move
+            assert axis.lower() in self.axis_names, ValueError("{0} is not a valid axis name.".format(axis))
+            querystring += axis.upper()
+            x = [x]
+        elif axis is None and relative:
+            # relative move
+            querystring += "R"
         if self.use_si_units: x = np.array(x) * 1e6
         for i in range(len(x)): querystring += " %d" % int(x[i]/self.resolution)
         self.query(querystring)


### PR DESCRIPTION
The Prior stage now uses serial commands to make single-axis moves directly, rather than emulating with the 3-axis move command.  This closes #37 as the cumulative drift should no longer be a problem.