### PR TITLE
Data browser improvements 2

### DIFF
--- a/nplab/datafile.py
+++ b/nplab/datafile.py
@@ -149,6 +149,18 @@ class Group(h5py.Group, ShowGUIMixin):
                  and re.match(r"_*(\d+)$", k[len(name):])]  # and end with numbers
         return sorted(items, key=h5_item_number)
 
+    def count_numbered_items(self, name):
+        """Count the number of items that would be returned by numbered_items
+        
+        If all you need to do is count how many items match a name, this is
+        a faster way to do it than len(group.numbered_items("name")).
+        """
+        n = 0
+        for k in self.keys():
+            if k.startswith(name) and re.match(r"_*(\d+)$", k[len(name):]):
+                n += 1
+                return n
+
     def create_group(self, name, attrs=None, auto_increment=True, timestamp=True):
         """Create a new group, ensuring we don't overwrite old ones.
 

--- a/nplab/datafile.py
+++ b/nplab/datafile.py
@@ -29,13 +29,9 @@ def attributes_from_dict(group_or_dataset, dict_of_attributes):
             try:
                 attrs[key] = value
             except TypeError:
-                print "Warning, metadata {0}='{1}' can't be saved in HDF5.  Saving with str()"
+                print "Warning, metadata {0}='{1}' can't be saved in HDF5.  Saving with str()".format(key, value)
                 attrs[key] = str(value)
-#            if key in attrs.keys():
-#                attrs.modify(key, value)
-#            else:
-#                attrs.create(key, value)
-    #group_or_dataset.attrs.update(dict_of_attributes)
+    #group_or_dataset.attrs.update(dict_of_attributes) #We can't do this - we'd lose the error handling.
 
 
 def h5_item_number(group_or_dataset):

--- a/nplab/instrument/__init__.py
+++ b/nplab/instrument/__init__.py
@@ -24,7 +24,6 @@ class Instrument(object, ShowGUIMixin):
     This class takes care of management of instruments, saving data, etc.
     """
     __instances = None
-#    description = String
     metadata_property_names = () #"Tuple of names of properties that should be automatically saved as HDF5 metadata
 
     def __init__(self):

--- a/nplab/instrument/stage/camera_stage_mapper.py
+++ b/nplab/instrument/stage/camera_stage_mapper.py
@@ -6,15 +6,18 @@ Created on Wed Jun 11 17:20:36 2014
 """
 import nplab.instrument.camera
 import nplab.instrument.stage
+from nplab.instrument import Instrument
 import cv2
 import cv2.cv
 from scipy import ndimage
 from traits.api import HasTraits, Button, Float, Int, Property, Range, Array, on_trait_change, Instance
 from traitsui.api import View, VGroup, Item
 import numpy as np
+import matplotlib
+import matplotlib.pyplot as plt
 import time, threading
 
-class CameraStageMapper(HasTraits):
+class CameraStageMapper(Instrument, HasTraits):
     """
     This class sits between a camera and a stage, allowing coordinate conversion.
 
@@ -53,6 +56,8 @@ class CameraStageMapper(HasTraits):
         self.camera_centre = (0.5,0.5)
         self.camera.set_legacy_click_callback(self.move_to_camera_point)
         self._action_lock = threading.Lock() #prevent us from doing two things involving motion at once!
+    
+    ############ Coordinate Conversion ##################
     def camera_pixel_to_point(self, p):
         """convert pixel coordinates to point coordinates (normalised 0-1)"""
         return np.array(p,dtype=float)/ \
@@ -72,6 +77,8 @@ class CameraStageMapper(HasTraits):
     def camera_pixel_displacement_to_sample(self, p):
         """Convert from pixels to microns for relative moves"""
         return self.camera_point_displacement_to_sample(self.camera_pixel_to_point(p))
+    
+    ############## Stage Control #####################
     def move_to_camera_pixel(self, p):
         """bring the object at pixel p=(x,y) on the camera to the centre"""
         return self.move_to_camera_point(*tuple(self.camera_pixel_to_point(p)))
@@ -87,12 +94,16 @@ class CameraStageMapper(HasTraits):
                               self.camera_to_sample)
         current_position = displacement +self.camera_centre_position()[0:2]
         self.move_to_sample_position(current_position)
+
     def move_to_sample_position(self, p):
         """Move the stage to centre sample position p on the camera"""
-        self.stage.move(-p)
+        self.stage.move(-np.array(p))
+    
     def camera_centre_position(self):
         """return the position of the centre of the camera view, on the sample"""
         return -self.stage.position
+    
+    ################## Closed loop stage control #################
     def centre_on_feature(self, feature_image, search_size=(50,50), tolerance=0.3, max_iterations=10, **kwargs):
         """Adjust the stage slightly to centre on the given feature.
         
@@ -164,50 +175,52 @@ class CameraStageMapper(HasTraits):
             print "sum(corr): ", np.sum(corr)
             print "max(corr): ", np.max(corr)
             raise e
+
+########## Calibration ###############
     @on_trait_change("do_calibration")
     def calibrate_in_background(self):
         threading.Thread(target=self.calibrate).start()
     def calibrate(self, dx=None):
         """Move the stage in a square and set the transformation matrix."""
-        self._action_lock.acquire()
-        if dx is None: dx=self.calibration_distance #use a sensible default
-        here = self.camera_centre_position()
-        pos = [np.array([i,j,0]) for i in [-dx,dx] for j in [-dx,dx]]
-        camera_pos = []
-        self.camera.update_latest_frame() # make sure we've got a fresh image
-        initial_image = self.camera.gray_image()
-        w, h, = initial_image.shape
-        template = initial_image[w/4:3*w/4,h/4:3*h/4] #.astype(np.float)
-        #template -= cv2.blur(template, (21,21), borderType=cv2.BORDER_REPLICATE)
-#        self.calibration_template = template
-#        self.calibration_images = []
-        camera_live_view = self.camera.live_view
-        if self.disable_live_view:
-            self.camera.live_view = False
-        for p in pos:
-            self.move_to_sample_position(here + p)
-            self.flush_camera_and_wait()
-            current_image = self.camera.gray_image()
-            corr = cv2.matchTemplate(current_image,template,cv2.TM_SQDIFF_NORMED)
-            corr *= -1. #invert the image
-            corr += (corr.max()-corr.min())*0.1 - corr.max() ##
-            corr = cv2.threshold(corr, 0, 0, cv2.THRESH_TOZERO)[1]
-#            peak = np.unravel_index(corr.argmin(),corr.shape)
-            peak = ndimage.measurements.center_of_mass(corr)
-            camera_pos.append(peak - (np.array(current_image.shape) - \
-                                                   np.array(template.shape))/2)
-#            self.calibration_images.append({"image":current_image,"correlation":corr,"pos":p,"peak":peak})
-        self.move_to_sample_position(here)
-        self.flush_camera_and_wait()#otherwise we get a worrying "jump" when enabling live view...
-        self.camera.live_view = camera_live_view
-        #camera_pos now contains the displacements in pixels for each move
-        sample_displacement = np.array([-p[0:2] for p in pos]) #nb need to convert to 2D, and the stage positioning is flipped from sample coords
-        camera_displacement = np.array([self.camera_pixel_to_point(p) for p in camera_pos])
-        print "sample was moved (in um):\n",sample_displacement
-        print "the image shifted (in fractions-of-a-camera):\n",camera_displacement
-        A, res, rank, s = np.linalg.lstsq(camera_displacement, sample_displacement)
-        self.camera_to_sample = A
-        self._action_lock.release()
+        with self._action_lock:
+            if dx is None: dx=self.calibration_distance #use a sensible default
+            here = self.camera_centre_position()
+            pos = [np.array([i,j,0]) for i in [-dx,dx] for j in [-dx,dx]]
+            camera_pos = []
+            self.camera.update_latest_frame() # make sure we've got a fresh image
+            initial_image = self.camera.gray_image()
+            w, h, = initial_image.shape
+            template = initial_image[w/4:3*w/4,h/4:3*h/4] #.astype(np.float)
+            #template -= cv2.blur(template, (21,21), borderType=cv2.BORDER_REPLICATE)
+    #        self.calibration_template = template
+    #        self.calibration_images = []
+            camera_live_view = self.camera.live_view
+            if self.disable_live_view:
+                self.camera.live_view = False
+            for p in pos:
+                self.move_to_sample_position(here + p)
+                self.flush_camera_and_wait()
+                current_image = self.camera.gray_image()
+                corr = cv2.matchTemplate(current_image,template,cv2.TM_SQDIFF_NORMED)
+                corr *= -1. #invert the image
+                corr += (corr.max()-corr.min())*0.1 - corr.max() ##
+                corr = cv2.threshold(corr, 0, 0, cv2.THRESH_TOZERO)[1]
+    #            peak = np.unravel_index(corr.argmin(),corr.shape)
+                peak = ndimage.measurements.center_of_mass(corr)
+                camera_pos.append(peak - (np.array(current_image.shape) - \
+                                                       np.array(template.shape))/2)
+    #            self.calibration_images.append({"image":current_image,"correlation":corr,"pos":p,"peak":peak})
+            self.move_to_sample_position(here)
+            self.flush_camera_and_wait()#otherwise we get a worrying "jump" when enabling live view...
+            self.camera.live_view = camera_live_view
+            #camera_pos now contains the displacements in pixels for each move
+            sample_displacement = np.array([-p[0:2] for p in pos]) #nb need to convert to 2D, and the stage positioning is flipped from sample coords
+            camera_displacement = np.array([self.camera_pixel_to_point(p) for p in camera_pos])
+            print "sample was moved (in um):\n",sample_displacement
+            print "the image shifted (in fractions-of-a-camera):\n",camera_displacement
+            A, res, rank, s = np.linalg.lstsq(camera_displacement, sample_displacement)
+            self.camera_to_sample = A
+
     def flush_camera_and_wait(self):
         """take and discard a number of images from the camera to make sure the image is fresh
         
@@ -215,6 +228,65 @@ class CameraStageMapper(HasTraits):
         time.sleep(self.settling_time)
         for i in range(self.frames_to_discard):
             self.camera.raw_image() #acquire, then discard, an image from the camera
+
+    ######## Image Tiling ############
+    def acquire_tiled_image(self, n_images=(3,3), dest=None, overlap=0.33,
+                            autofocus_args={},live_plot=False, downsample=8):
+        """Raster-scan the stage and take images, which we can later tile.
+
+        Arguments:
+        @param: n_images: A tuple of length 2 specifying the number of images
+        to take in X and Y
+        @param: dest: An HDF5 Group object to store the images in.  Each image
+        will be tagged with metadata to mark where it was taken.  If no dest
+        is specified, a new group will be created in the current datafile.
+        @param: overlap: the fraction of each image to overlap with the 
+        adjacent one (it's important this is high enough to match them up)
+        @param: autofocus_args: A dictionary of keyword arguments for the
+        autofocus that occurs before each image is taken.  Set to None to
+        disable autofocusing.
+        """
+        reset_interactive_mode = live_plot and not matplotlib.is_interactive()
+        if live_plot:
+            plt.ion()
+            fig = plt.figure()
+            axes = fig.add_subplot(111)
+            axes.set_aspect(1)
+            
+        with self._action_lock:
+            if dest is None:
+                dest = self.create_data_group("tiled_image_%d") #or should this be in RAM??
+            centre_position = self.camera_centre_position()[0:2] #only 2D
+            x_indices = np.arange(n_images[0]) - (n_images[0] - 1)/2.0
+            y_indices = np.arange(n_images[1]) - (n_images[1] - 1)/2.0
+            for y_index in y_indices:
+                for x_index in x_indices:
+                    position = centre_position + self.camera_point_displacement_to_sample(np.array([x_index, y_index]) * (1-overlap))
+                    self.move_to_sample_position(position) #go to the raster point
+                    if autofocus_args is not None:
+                        self.autofocus(**autofocus_args)
+                    self.flush_camera_and_wait() #wait for the camera to be ready/stage to settle
+                    tile = dest.create_dataset("tile_%d", 
+                                               data=self.camera.color_image(),
+                                               attrs=self.camera.metadata)
+                    tile.attrs.create("stage_position",self.stage.position)
+                    tile.attrs.create("camera_centre_position",self.camera_centre_position())
+                    if live_plot:
+                        #Plot the image, in sample coordinates
+                        corner_points = np.array([self.camera_point_to_sample((xcorner,ycorner)) 
+                                                for ycorner in [0,1] for xcorner in [0,1]]) #positions of corners
+                        plot_skewed_image(tile[::downsample, ::downsample, :],
+                                          corner_points, axes=axes)
+                        fig.canvas.draw()
+                x_indices = x_indices[::-1] #reverse the X positions, so we do a snake-scan
+            dest.attrs.set("camera_to_sample",self.camera_to_sample)
+            dest.attrs.set("camera_centre",self.camera_centre)
+            self.move_to_sample_position(centre_position) #go back to the start point
+        if reset_interactive_mode:
+            plt.ioff()
+        return dest
+        
+    ######## Autofocus Stuff #########
     def autofocus_merit_function(self): # we maximise this...
         """Take an image and calculate the focus metric, this is what we optimise.
         
@@ -226,11 +298,13 @@ class CameraStageMapper(HasTraits):
         img = self.camera.raw_image()
 #        return np.sum((img - cv2.blur(img,(21,21))).astype(np.single)**2)
         return np.sum(cv2.Laplacian(cv2.cvtColor(img,cv2.COLOR_BGR2GRAY), ddepth=cv2.CV_32F)**2)
+
     @on_trait_change("do_autofocus")
     def autofocus_in_background(self):
         def work():
             self.autofocus_iterate(np.arange(-self.autofocus_range/2, self.autofocus_range/2, self.autofocus_step))
         threading.Thread(target=work).start()
+    
     def autofocus_iterate(self, dz, method="centre_of_mass", noise_floor=0.3):
         self._action_lock.acquire()
         """Move in z and take images.  Move to the sharpest position."""
@@ -269,6 +343,7 @@ class CameraStageMapper(HasTraits):
         self.camera.live_view = camera_live_view
         self._action_lock.release()
         return new_position-here, positions, powers
+
     def autofocus(self, ranges=None, max_steps=10):
         """move the stage to bring the sample into focus
         
@@ -283,6 +358,7 @@ class CameraStageMapper(HasTraits):
             print "moving Z by %.3f" % pos[2]
             n+=1
         print "Autofocus: performed %d iterations" % n
+
 #if __name__ == '__main__':
     #WARNING this is old, probably broken, code.
 #    import nplab.instrument.camera.lumenera as camera

--- a/nplab/utils/gui.py
+++ b/nplab/utils/gui.py
@@ -101,7 +101,8 @@ def show_widget(Widget, *args, **kwargs):
 def show_guis(instruments, block=True):
     """Display the Qt user interfaces of a list of instruments."""
     app = get_qt_app()
-    uis = [i.get_qt_ui() for i in instruments if hasattr(i, "get_qt_ui")]
+    uis = [i.show_gui(blocking=False) for i in instruments if hasattr(i, "get_qt_ui")]
+    # DataBrowserImprovements swapped get_qt_ui for show_gui(block=False)
     traits = [i.edit_traits() for i in instruments if hasattr(i, "edit_traits")]
     for ui in uis:
         ui.show()

--- a/nplab/utils/matplotlib.py
+++ b/nplab/utils/matplotlib.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Fri Oct 02 20:13:01 2015
+
+@author: rwb27
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+import matplotlib
+from scipy import ndimage
+
+def plot_skewed_image(image, corners, axes=None, *args, **kwargs):
+    """Plot an image in a quadrilateral that has the given corners.
+    
+    Unfortunately, images plotted with the (very fast) imshow method must be
+    bounded by a rectangle with sides parallel to the axes.  This method allows
+    images to be plotted in an arbitrary quadrilateral, useful (for example) if
+    we want to plot images in units of stage displacement.
+    
+    @param: ax: A matplotlib axes object in which to plot the image
+    @param: image: An image, stored as an NxM or NxMx3 array
+    @param: corners: Coordinates of the corners of the array in the order
+    [bottom left, top left, bottom right, top right] as a list of tuples or a
+    4x2 array.
+    
+    Extra arguments/keyword arguments are passed to axes.pcolormesh
+    """
+    shape = image.shape
+    assert len(shape) == 2 or (len(shape) == 3 and (shape[2] == 3 or shape[2] == 4)), "the image argument must have shape (N*M) or (N*M*3) or (N*M*4)."                   
+    
+    if axes is None:
+        axes = plt.gca()
+    #First, we need to generate the coordinates of the vertices.  Start by
+    #putting the corner coordinates in a 2x2x2 array
+    assert np.array(corners).shape == (4,2), "The 'corners' argument must be four two-element positions, i.e. have shape (4, 2)"
+    corner_coordinate_array = np.array(corners).reshape((2,2,2))
+    #now, we "zoom" this array using bilinear interpolation (order=1) so that
+    #it has the correct dimensions - one greater than the size of the image.
+    coordinate_array = ndimage.zoom(corner_coordinate_array,
+                                    ((shape[0]+1)/2,(shape[1]+1)/2,1),
+                                    order=1)
+    if len(shape)==2: #grayscale image
+        mesh = ax.pcolormesh(coordinate_array[:,:,0],
+                             coordinate_array[:,:,1],
+                             image,
+                             *args
+                             **kwargs)
+    else:
+        #Sadly, pcolormesh doesn't seem to do RGB.  The work-around is to first
+        #plot a monochrome image, then set the color for each pixel later.
+        mesh = ax.pcolormesh(coordinate_array[:,:,0],
+                      coordinate_array[:,:,1],
+                      image[:,:,0],
+                      *args,
+                      **kwargs)
+        #we need to pass the colors as a flattened array of (R,G,B).  Worse,
+        #these need to be floating point values between 0 and 1!
+        if image.dtype == np.dtype('uint8'):
+            divisor = 255.0
+        elif image.dtype == np.dtype('uint16'):
+            divisor = 65535.0
+        elif image.max() <= 1.0:
+            divisor = 1.0
+        else:
+            divisor = image.max()
+            
+        mesh.set_color(image.reshape((shape[0]*shape[1],shape[2]))/divisor) 
+        
+if __name__ == '__main__':
+    image = np.random.random((100,100,3))
+    f = plt.figure()
+    ax = f.add_subplot(111)
+    print "Plotting..."
+    plot_skewed_image(image,[(0,0),(-0.5,1),(1,0.5),(0.5,1.5)],ax)
+    print "Drawing..."
+    f.canvas.draw()
+    print "Done"
+    plt.show()
+    

--- a/nplab/utils/show_gui_mixin.py
+++ b/nplab/utils/show_gui_mixin.py
@@ -50,7 +50,7 @@ class ShowGUIMixin:
             # nplab with dependencies on Qt.
             from nplab.utils.gui import get_qt_app, QtCore, QtGui
             app = get_qt_app()
-            if force_new_window or not isinstance(self.__gui_instance, qtgui.QWidget):
+            if force_new_window or not isinstance(self.__gui_instance, QtGui.QWidget):
                 # create the widget if it doesn't exist already, or if we've been
                 # told to make a new one
                 self.__gui_instance = self.get_qt_ui()

--- a/nplab/utils/show_gui_mixin.py
+++ b/nplab/utils/show_gui_mixin.py
@@ -16,7 +16,7 @@ class ShowGUIMixin:
     either a supplied Qt widget or using TraitsUI.
     """
     __gui_instance = None
-    def show_gui(self, blocking=True, force_new_window=False):
+    def show_gui(self, blocking=None, block=None, force_new_window=False):
         """Display a GUI window for the class.
 
         You may override this method to display a window to control the
@@ -32,8 +32,11 @@ class ShowGUIMixin:
         If you use blocking=False, it will return immediately - this allows
         you to continue using the console, assuming there's already a Qt
         application running (usually the case if you're running from 
-        Spyder).  NB you should hold on to the return value if using this
+        Spyder).  NB you may want to retain the return value if using this
         mode, as otherwise the GUI may be garbage-collected and disappear.
+        For compatibility, this function accepts either ``block`` or
+        ``blocking`` as a keyword argument - if either is not None it will
+        use that value, otherwise it defaults to ``True``.
 
         In the future, blocking=False may spawn a Qt application object in
         a background thread - but that's not currently done so we rely on
@@ -45,6 +48,10 @@ class ShowGUIMixin:
         cause issues if the retained reference to the GUI in the object is
         the only one existing - the previous window may disappear.
         """
+        if blocking is None and block is not None:
+            blocking = block # Allow the use of either argument name
+        if blocking is None:
+            blocking = True # We default to True.
         if hasattr(self,'get_qt_ui'):
             # NB this dynamic import is important to avoid saddling all of
             # nplab with dependencies on Qt.

--- a/nplab/utils/show_gui_mixin.py
+++ b/nplab/utils/show_gui_mixin.py
@@ -10,7 +10,13 @@ author: Richard Bowman
 """
 
 class ShowGUIMixin:
-    def show_gui(self, blocking=True):
+    """A mixin class to provide standard GUI functionality.
+
+    This class provides one method, which pops up a GUI window using 
+    either a supplied Qt widget or using TraitsUI.
+    """
+    __gui_instance = None
+    def show_gui(self, blocking=True, force_new_window=False):
         """Display a GUI window for the class.
 
         You may override this method to display a window to control the
@@ -30,18 +36,31 @@ class ShowGUIMixin:
         mode, as otherwise the GUI may be garbage-collected and disappear.
 
         In the future, blocking=False may spawn a Qt application object in
-        a background thread - but that's not currently done.
+        a background thread - but that's not currently done so we rely on
+        a Qt application running already (e.g. via the "input hook").
+        
+        When using Qt, we default to only creating one UI, and return a
+        handle to it each time this is called.  If ``force_new_window`` is 
+        set to `True`, a new widget will be created regardless.  This may
+        cause issues if the retained reference to the GUI in the object is
+        the only one existing - the previous window may disappear.
         """
         if hasattr(self,'get_qt_ui'):
             # NB this dynamic import is important to avoid saddling all of
             # nplab with dependencies on Qt.
-            from nplab.utils.gui import get_qt_app, qt
+            from nplab.utils.gui import get_qt_app, QtCore, QtGui
             app = get_qt_app()
-            ui = self.get_qt_ui()
+            if force_new_window or not isinstance(self.__gui_instance, qtgui.QWidget):
+                # create the widget if it doesn't exist already, or if we've been
+                # told to make a new one
+                self.__gui_instance = self.get_qt_ui()
+            ui = self.__gui_instance
             ui.show()
+            ui.activateWindow() #flash the taskbar entry to make it obvious
             if blocking:
                 print "Running GUI, this will block the command line until the window is closed."
-                ui.windowModality = qt.Qt.ApplicationModal
+                ui.windowModality = QtCore.Qt.ApplicationModal
+
                 try:
                     return app.exec_()
                 except:
@@ -55,7 +74,7 @@ class ShowGUIMixin:
                     self.configure_traits()
                 else:
                     self.edit_traits()
-            except NotImplementedError:
+            except AttributeError:
                 raise NotImplementedError("It looks like the show_gui \
                           method hasn't been subclassed, there isn't a \
                           get_qt_ui() method, and the instrument is not \

--- a/tests/test_data_browser.py
+++ b/tests/test_data_browser.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Tue Oct 27 13:09:09 2015
+
+@author: rwb27
+"""
+
+import nplab
+import numpy as np
+import matplotlib.pyplot as plt
+from numpy.random import random
+from nplab.ui.data_renderers import suitable_renderers
+
+if __name__ == '__main__':
+    df = nplab.current_datafile()
+    group = df.create_group("test_items")
+    
+    d = group.create_dataset("1d_generic",data=random((100)))
+    print suitable_renderers(d)
+    d = group.create_dataset("2d_generic",data=random((100,100)))
+    print suitable_renderers(d)
+    d = group.create_dataset("3d_rgb",data=random((100,100,3)))
+    print suitable_renderers(d)
+    d = group.create_dataset("3d_generic",data=random((100,100,100)))
+    print suitable_renderers(d)
+    
+    df.show_gui(block=True)
+    df.close()

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -133,7 +133,7 @@ def test_saving(capsys, tmpdir):
                                                 property_names=['bad_property']))
     assert "object" in d.attrs['bad_property'], "Fallback to str() failed for bad metadata"
     out, err = capsys.readouterr()
-    assert "Warning, metadata bad_property" in out
+    assert "Warning, metadata bad_property" in out, "Didn't get warning about bad_property: \n{}".format(out)
     
     df.close()
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -57,7 +57,7 @@ def test_long_log(tmpdir):
 
     instr = InstrumentA()
 
-    N = 10000
+    N = 1000
     for i in range(N):
         instr.do_something()
         print i


### PR DESCRIPTION
There was an old branch called "DataBrowserImprovements" with multiple bug-fixes.  I've reviewed the changes, tested them as best I can, and merged them in nicely.  There are a few helpful features:

* GUIs created with show_gui are now retained by the Instrument, meaning they only need to be created once.  This also helps stop them disappearing if blocking=False.
* show_gui now accepts a keyword argument "block" as a synonym for "blocking"
* HDF5 groups gain a new method, count_numbered_items, to quickly count the number of "numbered items" (this is much faster than ``len(numbered_items())``).
* camera_stage_mapper has additional comments and uses with blocks for locking rather than acquire() and release() calls
* camera_stage_mapper has code to acquire tiled images
* A utility module is added to plot skewed images in matplotlib (may be removed in future)
* fixed unit test for instrument
* added "unit test" for data browser (requires interactivity).