### PR TITLE
Added install_requires to accelerate package installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,4 +10,19 @@ setup(name='nplab',
       author_email='as2180@cam.ac.uk',
       license='',
       packages=find_packages(),
-      zip_safe=False)
+      zip_safe=False,
+      install_requires=[
+            "colorama",
+            "scipy",
+            "matplotlib",
+            "future",
+            "pyqtgraph",
+            "pillow",
+            "h5py",
+            "opencv-python",
+            "pyserial",
+            "pyvisa",
+            "qtpy",
+            "pip",
+            "PyQt5"
+      ])


### PR DESCRIPTION
Fixes #94 

Not fully ideal (traits are not installed, and open-cv is installed from an unofficial channel), but since people are working in different environments, it does the job of accelerating installation of packages