### PR TITLE
Fixes #96

### DIFF
--- a/nplab/instrument/stage/__init__.py
+++ b/nplab/instrument/stage/__init__.py
@@ -208,7 +208,7 @@ class StageUI(QtWidgets.QWidget, UiTools):
 #        for axis in axes:
 #            self.move_axis_absolute(0, axis)
 
-    def create_axes_layout(self, default_step=1e-6, stack_multiple_stages='horizontal'):
+    def create_axes_layout(self, default_step=1e-6, stack_multiple_stages='horizontal', arrange_buttons='stack'):
 
         uic.loadUi(os.path.join(os.path.dirname(__file__), 'stage.ui'), self)
         self.update_pos_button.clicked.connect(partial(self.update_positions, None))
@@ -268,21 +268,29 @@ class StageUI(QtWidgets.QWidget, UiTools):
             plus_button.clicked.connect(partial(self.move_axis_relative, i, ax, 1))
             minus_button = QtWidgets.QPushButton('', self)
             minus_button.clicked.connect(partial(self.move_axis_relative, i, ax, -1))
-            if i % 3 == 0:
+            if arrange_buttons == 'cross':
+                if i % 3 == 0:
+                    plus_button.setIcon(QtGui.QIcon(os.path.join(path, 'right.png')))
+                    minus_button.setIcon(QtGui.QIcon(os.path.join(path, 'left.png')))
+                    layout.addWidget(minus_button, 1, 0)
+                    layout.addWidget(plus_button, 1, 2)
+                elif i % 3 == 1:
+                    plus_button.setIcon(QtGui.QIcon(os.path.join(path, 'up.png')))
+                    minus_button.setIcon(QtGui.QIcon(os.path.join(path, 'down.png')))
+                    layout.addWidget(plus_button, 0, 1)
+                    layout.addWidget(minus_button, 2, 1)
+                elif i % 3 == 2:
+                    plus_button.setIcon(QtGui.QIcon(os.path.join(path, 'up.png')))
+                    minus_button.setIcon(QtGui.QIcon(os.path.join(path, 'down.png')))
+                    layout.addWidget(plus_button, 0, 3)
+                    layout.addWidget(minus_button, 2, 3)
+            elif arrange_buttons == 'stack':
                 plus_button.setIcon(QtGui.QIcon(os.path.join(path, 'right.png')))
                 minus_button.setIcon(QtGui.QIcon(os.path.join(path, 'left.png')))
-                layout.addWidget(minus_button, 1, 0)
-                layout.addWidget(plus_button, 1, 2)
-            elif i % 3 == 1:
-                plus_button.setIcon(QtGui.QIcon(os.path.join(path, 'up.png')))
-                minus_button.setIcon(QtGui.QIcon(os.path.join(path, 'down.png')))
-                layout.addWidget(plus_button, 0, 1)
-                layout.addWidget(minus_button, 2, 1)
-            elif i % 3 == 2:
-                plus_button.setIcon(QtGui.QIcon(os.path.join(path, 'up.png')))
-                minus_button.setIcon(QtGui.QIcon(os.path.join(path, 'down.png')))
-                layout.addWidget(plus_button, 0, 3)
-                layout.addWidget(minus_button, 2, 3)
+                layout.addWidget(minus_button, i % 3, 0)
+                layout.addWidget(plus_button, i % 3, 2)
+            else:
+                raise ValueError('Unrecognised arrangment: %s' % arrange_buttons)
             plus_button.setIconSize(icon_size)
             plus_button.resize(icon_size)
             minus_button.setIconSize(icon_size)

--- a/nplab/instrument/stage/__init__.py
+++ b/nplab/instrument/stage/__init__.py
@@ -208,7 +208,7 @@ class StageUI(QtWidgets.QWidget, UiTools):
 #        for axis in axes:
 #            self.move_axis_absolute(0, axis)
 
-    def create_axes_layout(self, default_step=1e-6, stack_multiple_stages='horizontal', arrange_buttons='stack'):
+    def create_axes_layout(self, default_step=1e-6, stack_multiple_stages='horizontal', arrange_buttons='cross'):
 
         uic.loadUi(os.path.join(os.path.dirname(__file__), 'stage.ui'), self)
         self.update_pos_button.clicked.connect(partial(self.update_positions, None))
@@ -239,19 +239,28 @@ class StageUI(QtWidgets.QWidget, UiTools):
             self.info_layout.addWidget(set_position_button, i % 3, col + 3)
 
             if i % 3 == 0:
-                group = QtWidgets.QGroupBox('axes {0}'.format(1 + (old_div(i, 3))), self)
-                layout = QtWidgets.QGridLayout()
-                layout.setSpacing(3)
-                group.setLayout(layout)
-                self.axes_layout.addWidget(group, 0, old_div(i, 3))
-                zero_button = QtWidgets.QPushButton('', self)
-                zero_button.setIcon(QtGui.QIcon(os.path.join(path, 'zero.png')))
-                zero_button.setIconSize(icon_size)
-                zero_button.resize(icon_size)
-                n = len(self.stage.axis_names) - i if len(self.stage.axis_names) - i < 3 else 3
-                axes_set = self.stage.axis_names[i:i + n]
-#                zero_button.clicked.connect(partial(self.zero_all_axes, axes_set))
-                layout.addWidget(zero_button, 1, 1)
+                if arrange_buttons == 'cross':
+                    group = QtWidgets.QGroupBox('axes {0}'.format(1 + (old_div(i, 3))), self)
+                    layout = QtWidgets.QGridLayout()
+                    layout.setSpacing(3)
+                    group.setLayout(layout)
+                    self.axes_layout.addWidget(group, 0, old_div(i, 3))
+                    zero_button = QtWidgets.QPushButton('', self)
+                    zero_button.setIcon(QtGui.QIcon(os.path.join(path, 'zero.png')))
+                    zero_button.setIconSize(icon_size)
+                    zero_button.resize(icon_size)
+
+                    layout.addWidget(zero_button, 1, 1)
+                    offset = 0
+                elif arrange_buttons == 'stack':
+                    layout = self.axes_layout
+                    offset = 7 * old_div(i, 3)
+
+                    zero_button = QtWidgets.QPushButton('', self)
+                    zero_button.setIcon(QtGui.QIcon(os.path.join(path, 'zero.png')))
+                    zero_button.setIconSize(icon_size)
+                    zero_button.resize(icon_size)
+                    layout.addWidget(zero_button, 1, i % 3 + 1 + offset)
 
             step_size_select = QtWidgets.QComboBox(self)
             step_size_select.addItems(list(self.step_size_values.keys()))
@@ -259,9 +268,9 @@ class StageUI(QtWidgets.QWidget, UiTools):
             step_str = engineering_format(default_step, self.stage.unit)
             step_index = list(self.step_size_values.keys()).index(step_str)
             step_size_select.setCurrentIndex(step_index)
-            layout.addWidget(QtWidgets.QLabel(str(ax), self), i % 3, 5)
-            layout.addWidget(step_size_select, i % 3, 6)
-            if i % 3 == 0:
+            layout.addWidget(QtWidgets.QLabel(str(ax), self), i % 3, 5 + offset)
+            layout.addWidget(step_size_select, i % 3, 6 + offset)
+            if i % 3 == 0 and arrange_buttons == 'cross':
                 layout.addItem(QtWidgets.QSpacerItem(12, 0), 0, 4)
 
             plus_button = QtWidgets.QPushButton('', self)
@@ -287,8 +296,8 @@ class StageUI(QtWidgets.QWidget, UiTools):
             elif arrange_buttons == 'stack':
                 plus_button.setIcon(QtGui.QIcon(os.path.join(path, 'right.png')))
                 minus_button.setIcon(QtGui.QIcon(os.path.join(path, 'left.png')))
-                layout.addWidget(minus_button, i % 3, 0)
-                layout.addWidget(plus_button, i % 3, 2)
+                layout.addWidget(minus_button, i % 3, 0 + offset)
+                layout.addWidget(plus_button, i % 3, 2 + offset)
             else:
                 raise ValueError('Unrecognised arrangment: %s' % arrange_buttons)
             plus_button.setIconSize(icon_size)

--- a/nplab/instrument/stage/__init__.py
+++ b/nplab/instrument/stage/__init__.py
@@ -208,7 +208,18 @@ class StageUI(QtWidgets.QWidget, UiTools):
 #        for axis in axes:
 #            self.move_axis_absolute(0, axis)
 
-    def create_axes_layout(self, default_step=1e-6, stack_multiple_stages='horizontal', arrange_buttons='cross'):
+    def create_axes_layout(self, default_step=1e-6, arrange_buttons='cross', rows=None):
+        """Layout of the PyQt widgets for absolute and relative movement of all axis
+
+        :param default_step:
+        :param arrange_buttons: either 'cross' or 'stack'. If 'cross', assumes the stages axes are x,y,z movement,
+        placing the arrows in an intuitive cross pattern
+        :param rows: number of rows per column when distributing the QtWidgets
+        :return:
+        """
+        if rows is None:
+            rows = np.ceil(np.sqrt(len(self.stage.axis_names)))
+        rows = int(rows)  # int is needed for the old_div and the modulo operations
 
         uic.loadUi(os.path.join(os.path.dirname(__file__), 'stage.ui'), self)
         self.update_pos_button.clicked.connect(partial(self.update_positions, None))
@@ -218,7 +229,7 @@ class StageUI(QtWidgets.QWidget, UiTools):
         self.set_positions = []
         self.set_position_buttons = []
         for i, ax in enumerate(self.stage.axis_names):
-            col = 4 * (old_div(i, 3))
+            col = 4 * (old_div(i, rows))
             position = QtWidgets.QLineEdit('', self)
             position.setReadOnly(True)
             self.positions.append(position)
@@ -233,34 +244,24 @@ class StageUI(QtWidgets.QWidget, UiTools):
             self.set_position_buttons.append(set_position_button)
             # for each stage axis add a label, a field for the current position,
             # a field to set a new position and a button to set a new position ..
-            self.info_layout.addWidget(QtWidgets.QLabel(str(ax), self), i % 3, col)
-            self.info_layout.addWidget(position, i % 3, col + 1)
-            self.info_layout.addWidget(set_position, i % 3, col + 2)
-            self.info_layout.addWidget(set_position_button, i % 3, col + 3)
+            self.info_layout.addWidget(QtWidgets.QLabel(str(ax), self), i % rows, col)
+            self.info_layout.addWidget(position, i % rows, col + 1)
+            self.info_layout.addWidget(set_position, i % rows, col + 2)
+            self.info_layout.addWidget(set_position_button, i % rows, col + 3)
 
-            if i % 3 == 0:
+            if i % rows == 0:
                 if arrange_buttons == 'cross':
-                    group = QtWidgets.QGroupBox('axes {0}'.format(1 + (old_div(i, 3))), self)
+                    group = QtWidgets.QGroupBox('axes {0}'.format(1 + (old_div(i, rows))), self)
                     layout = QtWidgets.QGridLayout()
                     layout.setSpacing(3)
                     group.setLayout(layout)
-                    self.axes_layout.addWidget(group, 0, old_div(i, 3))
-                    zero_button = QtWidgets.QPushButton('', self)
-                    zero_button.setIcon(QtGui.QIcon(os.path.join(path, 'zero.png')))
-                    zero_button.setIconSize(icon_size)
-                    zero_button.resize(icon_size)
-
-                    layout.addWidget(zero_button, 1, 1)
+                    self.axes_layout.addWidget(group, 0, old_div(i, rows))
                     offset = 0
                 elif arrange_buttons == 'stack':
                     layout = self.axes_layout
-                    offset = 7 * old_div(i, 3)
-
-                    zero_button = QtWidgets.QPushButton('', self)
-                    zero_button.setIcon(QtGui.QIcon(os.path.join(path, 'zero.png')))
-                    zero_button.setIconSize(icon_size)
-                    zero_button.resize(icon_size)
-                    layout.addWidget(zero_button, 1, i % 3 + 1 + offset)
+                    offset = 7 * old_div(i, rows)
+                else:
+                    raise ValueError('Unrecognised arrangment: %s' % arrange_buttons)
 
             step_size_select = QtWidgets.QComboBox(self)
             step_size_select.addItems(list(self.step_size_values.keys()))
@@ -268,8 +269,8 @@ class StageUI(QtWidgets.QWidget, UiTools):
             step_str = engineering_format(default_step, self.stage.unit)
             step_index = list(self.step_size_values.keys()).index(step_str)
             step_size_select.setCurrentIndex(step_index)
-            layout.addWidget(QtWidgets.QLabel(str(ax), self), i % 3, 5 + offset)
-            layout.addWidget(step_size_select, i % 3, 6 + offset)
+            layout.addWidget(QtWidgets.QLabel(str(ax), self), i % rows, 5 + offset)
+            layout.addWidget(step_size_select, i % rows, 6 + offset)
             if i % 3 == 0 and arrange_buttons == 'cross':
                 layout.addItem(QtWidgets.QSpacerItem(12, 0), 0, 4)
 
@@ -278,17 +279,17 @@ class StageUI(QtWidgets.QWidget, UiTools):
             minus_button = QtWidgets.QPushButton('', self)
             minus_button.clicked.connect(partial(self.move_axis_relative, i, ax, -1))
             if arrange_buttons == 'cross':
-                if i % 3 == 0:
+                if i % rows == 0:
                     plus_button.setIcon(QtGui.QIcon(os.path.join(path, 'right.png')))
                     minus_button.setIcon(QtGui.QIcon(os.path.join(path, 'left.png')))
                     layout.addWidget(minus_button, 1, 0)
                     layout.addWidget(plus_button, 1, 2)
-                elif i % 3 == 1:
+                elif i % rows == 1:
                     plus_button.setIcon(QtGui.QIcon(os.path.join(path, 'up.png')))
                     minus_button.setIcon(QtGui.QIcon(os.path.join(path, 'down.png')))
                     layout.addWidget(plus_button, 0, 1)
                     layout.addWidget(minus_button, 2, 1)
-                elif i % 3 == 2:
+                elif i % rows == 2:
                     plus_button.setIcon(QtGui.QIcon(os.path.join(path, 'up.png')))
                     minus_button.setIcon(QtGui.QIcon(os.path.join(path, 'down.png')))
                     layout.addWidget(plus_button, 0, 3)
@@ -296,8 +297,8 @@ class StageUI(QtWidgets.QWidget, UiTools):
             elif arrange_buttons == 'stack':
                 plus_button.setIcon(QtGui.QIcon(os.path.join(path, 'right.png')))
                 minus_button.setIcon(QtGui.QIcon(os.path.join(path, 'left.png')))
-                layout.addWidget(minus_button, i % 3, 0 + offset)
-                layout.addWidget(plus_button, i % 3, 2 + offset)
+                layout.addWidget(minus_button, i % rows, 0 + offset)
+                layout.addWidget(plus_button, i % rows, 1 + offset)
             else:
                 raise ValueError('Unrecognised arrangment: %s' % arrange_buttons)
             plus_button.setIconSize(icon_size)


### PR DESCRIPTION
Mostly just an extension of the previous StageUI, now allowing for stacking (with variable number of rows) of the QtWidgets for axes movement.
But no one seems to be using the old code, so I took some potentially bug-prone steps to keep in mind:
- Removed `stack_multiple_stages` from the arguments of `create_axes_layout`. I didn't remove it from the PiezoStageUI, since it doesn't seem to be properly inheriting anyway
- Removed the central button, since it's not connected to anything